### PR TITLE
Fix bug with some xml responses.

### DIFF
--- a/huaweisms/xml/util.py
+++ b/huaweisms/xml/util.py
@@ -44,6 +44,9 @@ def get_dictionary_from_children(elem):
                 ret[n] = get_dictionary_from_children(node)
             elif isinstance(ret[n], list):
                 ret[n].append(get_dictionary_from_children(node))
+            elif isinstance(ret[n], dict):
+                previous_val = ret[n]
+                ret[n] = [previous_val, get_dictionary_from_children(node)]
             else:
                 ret[n] = get_dictionary_from_children(node)
 


### PR DESCRIPTION
When the response has only 2 elements, "minidom" returns every child node as a dictionary, so this was causing that the second element overwrites the first one (since it was entering on the "else" statement).
However, it was working without problems when the xml response has more than 2 elements, since "minidom" returns every child node as a list.